### PR TITLE
StorageClass is not namespace level object so namespace is not needed

### DIFF
--- a/controllers/pachyderm_controller.go
+++ b/controllers/pachyderm_controller.go
@@ -610,7 +610,6 @@ func (r *PachydermReconciler) reconcileStorageClass(ctx context.Context, compone
 		userStorageClass := &storagev1.StorageClass{}
 		userSCKey := types.NamespacedName{
 			Name:      storageClassName,
-			Namespace: pachyderm.Namespace,
 		}
 		if err := r.Get(ctx, userSCKey, userStorageClass); err != nil {
 			return err


### PR DESCRIPTION
ETCD need PVC and the pachyderm CR can specify SC name.

But operator can not find the SC even it exist because it specified a namespace so I removed it.

#2 