### PR TITLE
base64 check condition is wrong. It should be !=. 

### DIFF
--- a/controllers/generators/manifests.go
+++ b/controllers/generators/manifests.go
@@ -389,7 +389,7 @@ func setupStorageSecret(secret *corev1.Secret, pd *aimlv1beta1.Pachyderm) {
 // accepts string and returns a slice of type bytes
 func toBytes(value string) []byte {
 	if aimlv1beta1.IsBase64Encoded(value) {
-		if out, err := base64.StdEncoding.DecodeString(value); err == nil {
+		if out, err := base64.StdEncoding.DecodeString(value); err != nil {
 			return out
 		}
 	}


### PR DESCRIPTION
Simple check logic bug.

With this condition, string "true" value can not be encoded.

#4 